### PR TITLE
Start process using exec in entrypoint.sh script.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,4 +24,4 @@ upstream theservice { \\
 } \\
 " > /etc/nginx/conf.d/proxy.conf
 
-nginx -g "daemon off;"
+exec nginx -g "daemon off;"


### PR DESCRIPTION
In entrypoint script the process must be started using exec to propagate the signals.
